### PR TITLE
Update cmake to use BUILD_TESTING variable for test logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,10 +35,7 @@ PROJECT( ${PROJ} LANGUAGES CXX )
 INCLUDE( cmake/macros.cmake )
 
 # Enable testing
-IF ( NOT DISABLE_TESTS )
-    ENABLE_TESTING()
-    INCLUDE( CTest )
-ENDIF()
+INCLUDE( CTest )
 
 # Create a release target
 INCLUDE( cmake/WriteRepoVersion.cmake )
@@ -185,7 +182,7 @@ INSTALL( FILES "${CMAKE_CURRENT_BINARY_DIR}/cmake/StackTraceConfig.cmake" "${CMA
         DESTINATION ${${PROJ}_INSTALL_DIR}/lib/cmake/StackTrace )
 
 # Add the tests
-IF ( NOT DISABLE_TESTS )
+IF ( BUILD_TESTING )
     ADD_EXE( TestStack TestStack.cpp )
     ADD_EXE( TestTerminate TestTerminate.cpp )
     ADD_EXE( TestUtilities TestUtilities.cpp )


### PR DESCRIPTION
Per @rbberger this removes the DISABLE_TESTING flag and uses the BUILD_TESTING cache variable.